### PR TITLE
desktop: add desktop entry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,4 +54,8 @@ add_executable(hyprpwcenter ${SRCFILES})
 
 target_link_libraries(hyprpwcenter PkgConfig::deps)
 
+install(
+  FILES contrib/hyprpwcenter.desktop
+  DESTINATION "share/applications")
+
 install(TARGETS hyprpwcenter)

--- a/contrib/hyprpwcenter.desktop
+++ b/contrib/hyprpwcenter.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Hyprpwcenter
+Comment=A GUI Pipewire control center 
+Exec=hyprpwcenter
+Icon=audio-speakers
+Terminal=false
+Type=Application
+Categories=AudioVideo;Audio;Mixer;Settings;
+Keywords=hyprpwcenter;Pipewire;Microphone;Volume;Fade;Balance;Headset;Speakers;Headphones;Audio;Mixer;Output;Input;Devices;Playback;Recording;System Sounds;Sound Card;Settings;Preferences;


### PR DESCRIPTION
It makes sense to add a desktop entry as this is a graphical GUI. This mr does just that

Two things to check:
* is the name `Hyprpwcenter` fine? I guess `HyprPWCenter` would look weird
* is the file placement in `./contrib/hyprpwcenter.desktop` fine?

Related to https://github.com/hyprwm/hyprpwcenter/issues/4