### PR TITLE
i18n: add Persian translation

### DIFF
--- a/src/i18n/Engine.cpp
+++ b/src/i18n/Engine.cpp
@@ -122,6 +122,23 @@ void I18n::initEngine() {
     engine.registerEntry("it_IT", TXT_KEY_GRAPH_ACTIVE_OUTPUTS, "Usicte attive");
     engine.registerEntry("it_IT", TXT_KEY_GRAPH_PURE_OUTPUTS, "Uscite non connesse");
 
+    // fa_IR (Persian)
+    engine.registerEntry("fa_IR", TXT_KEY_PW_CENTER_TITLE, "مرکز کنترل Pipewire");
+
+    engine.registerEntry("fa_IR", TXT_KEY_BUTTON_APPS, "برنامه‌ها");
+    engine.registerEntry("fa_IR", TXT_KEY_BUTTON_NODES, "گره‌ها");
+    engine.registerEntry("fa_IR", TXT_KEY_BUTTON_INPUTS, "ورودی‌ها");
+    engine.registerEntry("fa_IR", TXT_KEY_BUTTON_CONFIGURATION, "تنظیمات");
+    engine.registerEntry("fa_IR", TXT_KEY_BUTTON_GRAPH, "گراف");
+
+    engine.registerEntry("fa_IR", TXT_KEY_GRAPH_N_PORTS, "{count} پورت");
+    engine.registerEntry("fa_IR", TXT_KEY_GRAPH_PURE_INPUTS, "فقط ورودی‌ها");
+    engine.registerEntry("fa_IR", TXT_KEY_GRAPH_ACTIVE_INPUTS, "ورودی‌های فعال");
+    engine.registerEntry("fa_IR", TXT_KEY_GRAPH_UNCONNECTED_IO, "ورودی/خروجی‌های غیرفعال");
+    engine.registerEntry("fa_IR", TXT_KEY_GRAPH_ACTIVE_IO, "ورودی/خروجی‌های فعال");
+    engine.registerEntry("fa_IR", TXT_KEY_GRAPH_ACTIVE_OUTPUTS, "خروجی‌های فعال");
+    engine.registerEntry("fa_IR", TXT_KEY_GRAPH_PURE_OUTPUTS, "فقط خروجی‌ها");
+
     // fi_FI (Finnish)
     engine.registerEntry("fi_FI", TXT_KEY_PW_CENTER_TITLE, "Pipewire-ohjauskeskus");
 


### PR DESCRIPTION
It appears some languages here are sorted alphabetically by their English exonym, while others are sorted according to their locale (e.g., Persian vs. fa_IR). Either way, they remain unsorted.

I’ve placed the Persian block according to its locale-based sorting for now. I would make another MR for proper sorting but i can't push to github anymore ([country wide issue](https://en.wikipedia.org/wiki/2026_Internet_blackout_in_Iran), github still not fully whitelisted).