### PR TITLE
feat: Added support for node names

### DIFF
--- a/src/pw/PwNode.cpp
+++ b/src/pw/PwNode.cpp
@@ -107,7 +107,18 @@ CPipewireNode::CPipewireNode(uint32_t id, uint32_t permissions, const char* type
     m_id = id;
 
     auto        mc  = prop(props, PW_KEY_MEDIA_CLASS);
-    const char* nm  = prop(props, PW_KEY_NODE_NAME);
+    const char* an = spa_dict_lookup(props, PW_KEY_APP_NAME);
+    const char* nn = spa_dict_lookup(props, PW_KEY_NODE_NAME);
+
+    std::string nmStr;
+    if (an && nn && strcmp(an, nn) != 0)
+        nmStr = std::string(an) + ": " + nn;
+    else if (nn)
+        nmStr = nn;
+    else if (an)
+        nmStr = an;
+
+    const char* nm = nmStr.empty() ? nullptr : nmStr.c_str();
     const char* dsc = prop(props, PW_KEY_NODE_DESCRIPTION);
 
     m_name = dsc ? dsc : (nm ? nm : "");


### PR DESCRIPTION
This PR aims to implement node name handling.
Without this, some apps appear under weird names, such as `Playback` and `Capture` for Mumble.

Before:
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/6286bd41-1b99-4af9-bddf-ae6b2032a8de" />

After:
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/25e11381-122f-4050-bb67-2c60a0de39d1" />

This PR is possible thanks to the original fix for GPU Screen Recorder:
https://git.dec05eba.com/gpu-screen-recorder/commit/?id=50536274b6b95654aa3d7a9bfad4f77240d4f75c

I did utilize Claude to learn what type and methods I should use for strings as I am not yet familiar with that API.

closes #52 